### PR TITLE
Add QuoteChime

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -1661,5 +1661,14 @@
     "description": "Core Python library for astronomy and astrophysics, providing common tools for the field.",
     "license": "BSD-3-Clause",
     "added": "2026-08-05"
+  },
+  {
+    "name": "QuoteChime",
+    "repo": "eswain89-web/quotechime-free",
+    "homepage": "https://quotechime.pages.dev/?ref=ossdrop",
+    "category": "finance-business",
+    "description": "Browser-private quote follow-up message generator for Australian trade and service businesses.",
+    "license": "MIT",
+    "added": "2026-08-05"
   }
 ]


### PR DESCRIPTION
## What tool are you dropping?

QuoteChime — a browser-private quote follow-up message generator for Australian trade and service businesses.

## Checklist

- [x] I edited **only** `data/tools.json` (not README.md — it is generated)
- [x] One tool in this PR
- [x] Public repo with an OSI-approved license, and the `license` field matches
- [x] Description is one honest sentence, 140 characters max — no hype
- [x] `category` is one of the slugs listed in CONTRIBUTING.md
- [x] No star counts or other metrics typed by hand

The MIT-licensed core is usable directly from GitHub Pages without an account. The project homepage also links optional one-time downloads.