### PR TITLE
Add Atomic Agent to ai-coding-agents

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -2093,5 +2093,20 @@
     "description": "Static-site generator for building and maintaining documentation websites.",
     "license": "MIT",
     "added": "2026-08-13"
+  },
+  {
+    "name": "Atomic Agent",
+    "repo": "AtomicBot-ai/atomic-agent",
+    "homepage": "https://atomicagent.io",
+    "category": "ai-coding-agents",
+    "description": "Local-first CLI and TUI coding agent that runs open-weight models entirely on your machine, with no account or API key required.",
+    "license": "MIT",
+    "links": [
+      {
+        "label": "docs",
+        "url": "https://atomicagent.io/docs"
+      }
+    ],
+    "added": "2026-08-13"
   }
 ]


### PR DESCRIPTION
## What tool are you dropping?

**Atomic Agent** - a local-first CLI and TUI coding agent that runs open-weight models entirely on your machine, with no account or API key required.

Hi! I'm the CPO of Atomic Agent. Thanks for building this list, and for making it clear that makers can drop their own tools. Our team would be thrilled to be included.

A few notes for the review:

- **Category:** `ai-coding-agents`. Its job is the AI itself (a coding agent that plans, edits files, and runs tools), so it sits with Aider and Continue rather than in `developer-tools-cli`.
- **Honest status:** our README carries an official notice that this is a developer preview - APIs, commands, config, and behavior are still moving. There's no field for that in the schema, so I'm flagging it here rather than putting it in the description. Happy to word the entry differently if you'd prefer it stated in the list itself.
- **Name collision worth knowing about:** there is a separate, unrelated project called "Atomic Agents" (`BrainBlend-AI/atomic-agents`). Ours is `AtomicBot-ai/atomic-agent`, by the AtomicBot-ai organization. Not currently in the list, but flagging it so a future duplicate check doesn't get confused.
- **License:** MIT, matching the `license` field and the LICENSE file in the repo.

What it does: runs open-weight models locally through a llama.cpp fork, ships 56 built-in tools (browser, filesystem, git, memory, vision), supports MCP, and has a five-layer local memory system. TUI is built on React and ink. Works on macOS, Linux, and Windows.

Install: `curl -fsSL https://atomicagent.io/install | sh`

Links: [site](https://atomicagent.io) - [docs](https://atomicagent.io/docs) - [X](https://x.com/atomicagent_io) - [Discord](https://discord.gg/Us7qXtDGw)

I ran `scripts/build_readme.py`'s `validate()` locally against the modified `data/tools.json`: it passes for all 227 entries, and our description is 128 characters.

## Checklist

- [x] I edited **only** `data/tools.json` (not README.md - it's generated)
- [x] One tool in this PR
- [x] Public repo with an OSI-approved license, and the `license` field matches
- [x] Description is one honest sentence, 140 characters max - no hype
- [x] `category` is one of the slugs listed in CONTRIBUTING.md
- [x] No star counts or other metrics typed by hand (they're fetched automatically)
