### PR TITLE
Add Posnic point-of-sale software

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -2687,5 +2687,24 @@
     "description": "Dependency-free GitHub Action that finds risky static HTML form endpoints, methods, and omitted field names before deployment.",
     "license": "MIT",
     "added": "2026-08-23"
+  },
+  {
+    "name": "Posnic",
+    "repo": "Posnic/POS",
+    "homepage": "https://posnic.com/",
+    "category": "finance-business",
+    "description": "Offline-first point-of-sale software for retail and restaurants, with local billing, inventory, reports, and public AGPL source.",
+    "license": "AGPL-3.0-only",
+    "links": [
+      {
+        "label": "download",
+        "url": "https://posnic.com/download"
+      },
+      {
+        "label": "developer documentation",
+        "url": "https://posnic.com/developers"
+      }
+    ],
+    "added": "2026-08-21"
   }
 ]


### PR DESCRIPTION
Adds Posnic to the finance-business category using the repository's published AGPL-3.0-only license and a factual 128-character description. The entry links to the public source, product site, clean download URL, and developer documentation. JSON parsing, uniqueness, category, license, and description-length checks pass.

The wording intentionally says "public AGPL source" because the distributed desktop package includes separately licensed components documented by Posnic.