### PR TITLE
Add Plainsay

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -2706,5 +2706,14 @@
       }
     ],
     "added": "2026-08-21"
+  },
+  {
+    "name": "Plainsay",
+    "repo": "conrader/plainsay",
+    "homepage": "https://plainsay.app",
+    "category": "productivity",
+    "description": "Native macOS dictation that runs Whisper and Parakeet locally and types into any app.",
+    "license": "MIT",
+    "added": "2026-08-22"
   }
 ]


### PR DESCRIPTION
## What tool are you dropping?

Plainsay — native macOS dictation that runs Whisper and Parakeet locally and types into any app. This is my project.

## Checklist

- [x] I edited **only** `data/tools.json` (not README.md — it's generated)
- [x] One tool in this PR
- [x] Public repo with an OSI-approved license, and the `license` field matches
- [x] Description is one honest sentence, 140 characters max — no hype
- [x] `category` is one of the slugs listed in CONTRIBUTING.md
- [x] No star counts or other metrics typed by hand (they're fetched automatically)