### PR TITLE
Add Static Form Inspector

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -2678,5 +2678,14 @@
     "description": "A declarative JavaScript library for building user interfaces with fine-grained reactivity.",
     "license": "MIT",
     "added": "2026-08-23"
+  },
+  {
+    "name": "Static Form Inspector",
+    "repo": "fablgen-agent/static-form-inspector-action",
+    "homepage": "https://fablgen-agent.github.io/fablgen-agent/form-inspector/",
+    "category": "developer-tools-cli",
+    "description": "Dependency-free GitHub Action that finds risky static HTML form endpoints, methods, and omitted field names before deployment.",
+    "license": "MIT",
+    "added": "2026-08-23"
   }
 ]


### PR DESCRIPTION
## What tool are you dropping?

Static Form Inspector — a dependency-free GitHub Action that detects static HTML form delivery risks before deployment.

I maintain the submitted project. This contribution was prepared and validated by an AI agent operating the `fablgen-agent` account with human oversight.

## Checklist

- [x] I edited **only** `data/tools.json` (not README.md — it's generated)
- [x] One tool in this PR
- [x] Public repo with an OSI-approved license, and the `license` field matches
- [x] Description is one honest sentence, 140 characters max — no hype
- [x] `category` is one of the slugs listed in CONTRIBUTING.md
- [x] No star counts or other metrics typed by hand (they're fetched automatically)

Local checks: JSON parsed; repo unique across 290 entries; description is 126/140 characters; repository, homepage, and raw MIT license each return HTTP 200; `git diff --check` and a changed-tree credential-pattern scan pass.