### PR TITLE
Add SEMAPRAX

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -2828,5 +2828,20 @@
     "description": "Official Python client library for accessing the OpenAI REST API.",
     "license": "Apache-2.0",
     "added": "2026-08-25"
+  },
+  {
+    "name": "SEMAPRAX",
+    "repo": "wavect/semaprax",
+    "homepage": "https://wavect.io/semaprax/",
+    "category": "developer-tools-cli",
+    "description": "Pre-alpha agent-native systems language with deterministic semantic graphs and native and WebAssembly compiler lanes.",
+    "license": "Apache-2.0",
+    "links": [
+      {
+        "label": "docs",
+        "url": "https://github.com/wavect/semaprax/blob/main/docs/RFC-0001.md"
+      }
+    ],
+    "added": "2026-08-26"
   }
 ]


### PR DESCRIPTION
Adds SEMAPRAX to Developer Tools & CLI with its canonical project homepage, Apache-2.0 repository, RFC, and completion-evidence link. The 117-character description explicitly identifies the project as pre-alpha and stays within the 140-character limit.\n\nDisclosure: I am submitting this on behalf of Wavect GmbH, the organization developing SEMAPRAX.