### PR TITLE
Add Codex Quota Overlay

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -3047,5 +3047,14 @@
     "description": "Library of models, datasets and tools for applying end-to-end machine learning to real-world robotics.",
     "license": "Apache-2.0",
     "added": "2026-08-28"
+  },
+  {
+    "name": "Codex Quota Overlay",
+    "repo": "cpys/codex-quota-overlay",
+    "homepage": "https://cpys.github.io/codex-quota-overlay/",
+    "category": "developer-tools-cli",
+    "description": "Windows tray overlay and local dashboard for Codex quota windows, reset times, pacing, forecasts, and usage activity.",
+    "license": "MIT",
+    "added": "2026-08-28"
   }
 ]


### PR DESCRIPTION
Summary: add Codex Quota Overlay to data/tools.json under developer-tools-cli. The description is factual and within the 140-character limit. I maintain Codex Quota Overlay; it is an independent MIT-licensed open-source project and is not affiliated with OpenAI. The entry uses public repository metadata and makes no sponsorship, paid-placement, or adoption claim.