### PR TITLE
Add CreateForge UI Lab

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -2843,5 +2843,14 @@
       }
     ],
     "added": "2026-08-26"
+  },
+  {
+    "name": "CreateForge UI Lab",
+    "repo": "Mr-ZhangBo/ai-model-prompt-brief-builder",
+    "homepage": "https://mr-zhangbo.github.io/ai-model-prompt-brief-builder/",
+    "category": "creator-media",
+    "description": "Local-first browser tool for comparing 17 AI image and video model profiles and exporting model-aware creative briefs.",
+    "license": "MIT",
+    "added": "2026-08-26"
   }
 ]


### PR DESCRIPTION
Adds CreateForge UI Lab as a creator-media tool.\n\n- Public MIT-licensed repository\n- Working dependency-free browser demo\n- Local-first reference previews with no upload or generation requests\n- Honest 118-character description and one data/tools.json object\n\nI am submitting my own project. The optional hosted generation link identifies the separate hosted service; the open-source UI Lab remains fully usable locally without an account, API key, or backend.