### PR TITLE
Add YunCMS to web-apis

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -2861,5 +2861,20 @@
     "description": "Dependency-free browser calculator and JavaScript reference for converting Celsius, Fahrenheit, kelvin, and Rankine.",
     "license": "MIT",
     "added": "2026-08-26"
+  },
+  {
+    "name": "YunCMS",
+    "repo": "Yunsoft-Software/yuncms",
+    "homepage": "https://github.com/Yunsoft-Software/yuncms",
+    "category": "web-apis",
+    "description": "Self-hosted MySQL CMS and REST backend with a React Studio, role-based access control, files, extensions, and MCP.",
+    "license": "MIT",
+    "links": [
+      {
+        "label": "docs",
+        "url": "https://github.com/Yunsoft-Software/yuncms/tree/main/docs"
+      }
+    ],
+    "added": "2026-08-26"
   }
 ]


### PR DESCRIPTION
## What tool are you dropping?

YunCMS — a self-hosted MySQL CMS and REST backend with a React administration Studio. The current release line is pre-stable (`0.1.x`).

`web-apis` is the closest existing category because YunCMS provides the REST backend and administration layer for web applications; the directory currently has no CMS-specific category.

## Checklist

- [x] I edited **only** `data/tools.json` (not README.md — it is generated)
- [x] One tool in this PR
- [x] Public repo with an OSI-approved license, and the `license` field matches
- [x] Description is one honest sentence, 140 characters max — no hype
- [x] `category` is one of the slugs listed in CONTRIBUTING.md
- [x] No star counts or other metrics typed by hand (they are fetched automatically)

## Validation

- `python3 -m json.tool data/tools.json`
- Repository validator in `scripts/build_readme.py` (114/140 description characters)