### PR TITLE
Add SessionSifu

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -3272,5 +3272,14 @@
     "description": "Open standard format for representing machine learning models across frameworks.",
     "license": "Apache-2.0",
     "added": "2026-09-01"
+  },
+  {
+    "name": "SessionSifu",
+    "repo": "tpluharik/SessionSifu",
+    "homepage": "https://github.com/tpluharik/SessionSifu",
+    "category": "productivity",
+    "description": "Restores desktop applications, documents, workspaces, and window layouts, with an optional private local visual timeline.",
+    "license": "GPL-3.0",
+    "added": "2026-09-01"
   }
 ]


### PR DESCRIPTION
Adds SessionSifu, an open-source cross-platform desktop session restoration tool with an optional private local visual timeline, to the Productivity category.\n\n- Public repository: https://github.com/tpluharik/SessionSifu\n- License: GPL-3.0\n- Description: 119 characters and intentionally factual\n- One tool added; generated files left untouched