### PR TITLE
feat: add Authier password manager

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -3281,5 +3281,20 @@
     "description": "Restores desktop applications, documents, workspaces, and window layouts, with an optional private local visual timeline.",
     "license": "GPL-3.0",
     "added": "2026-09-01"
+  },
+  {
+    "name": "Authier",
+    "repo": "authier-pm/authier",
+    "homepage": "https://www.authier.pm/",
+    "category": "security-privacy",
+    "description": "Open-source password manager with browser autofill, encrypted vault sync, TOTP codes, and trusted-device approval.",
+    "license": "AGPL-3.0",
+    "links": [
+      {
+        "label": "docs",
+        "url": "https://www.authier.pm/security"
+      }
+    ],
+    "added": "2026-09-01"
   }
 ]


### PR DESCRIPTION
## What tool are you dropping?

Authier — an open-source password manager with browser autofill, encrypted vault sync, TOTP codes, and trusted-device approval.

## Checklist

- [x] I edited **only** `data/tools.json` (not README.md — it is generated)
- [x] One tool in this PR
- [x] Public repo with an OSI-approved license, and the `license` field matches
- [x] Description is one honest sentence, 140 characters max — no hype
- [x] `category` is one of the slugs listed in CONTRIBUTING.md
- [x] No star counts or other metrics typed by hand