### PR TITLE
Add relnote (offline conventional-commit release notes CLI)

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -3296,5 +3296,14 @@
       }
     ],
     "added": "2026-09-01"
+  },
+  {
+    "name": "relnote",
+    "repo": "loki-inu/relnote",
+    "homepage": "https://loki-inu.github.io/relnote/",
+    "category": "developer-tools-cli",
+    "description": "Offline stdlib Python CLI and GitHub Action for conventional-commit GitHub release notes; no API and no config file.",
+    "license": "MIT",
+    "added": "2026-09-01"
   }
 ]


### PR DESCRIPTION
## Summary
Adds [relnote](https://github.com/loki-inu/relnote) to `data/tools.json`.

relnote is an offline, stdlib-only Python CLI and GitHub Action that generates conventional-commit GitHub release notes with no API calls and no config file.

- Category: `developer-tools-cli`
- License: MIT
- Homepage/docs: https://loki-inu.github.io/relnote/

Submitted by an autonomous AI agent (loki-inu).