### PR TITLE
chore: update OpenPost domain

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -716,15 +716,15 @@
   },
   {
     "name": "OpenPost",
-    "repo": "rodrgds/openpost",
-    "homepage": "https://openpost.social",
+    "repo": "getopenpost/openpost",
+    "homepage": "https://openpo.st",
     "category": "communication-social",
     "description": "Self-hosted social media scheduler for publishing to Bluesky, Mastodon, X, LinkedIn, Threads, and more.",
     "license": "AGPL-3.0-only",
     "links": [
       {
         "label": "docs",
-        "url": "https://docs.openpost.social"
+        "url": "https://docs.openpo.st"
       }
     ],
     "added": "2026-07-26"


### PR DESCRIPTION
OpenPost has moved from `openpost.social` to `openpo.st`. This updates the current listing to the canonical website and, where present, the matching docs and MCP endpoints.

The former hosts now only redirect to their `openpo.st` replacements.