### PR TITLE
Add MailKite SaaS Starter (Next.js SaaS starter with self-contained auth)

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -3476,5 +3476,14 @@
     "description": "A JavaScript and REST API-based interface for reading, managing, and publishing to WordPress.com and Jetpack-connected sites.",
     "license": "GPL-2.0",
     "added": "2026-09-05"
+  },
+  {
+    "name": "MailKite SaaS Starter",
+    "repo": "mailkite/saas-startup",
+    "homepage": "https://saas-startup.mailkite.dev",
+    "category": "web-apis",
+    "description": "Next.js SaaS starter for developers: auth, Stripe subscriptions and teams run inside your own app, with no auth vendor needed.",
+    "license": "MIT",
+    "added": "2026-09-06"
   }
 ]


### PR DESCRIPTION
## What tool are you dropping?

MailKite SaaS Starter — an MIT-licensed Next.js SaaS starter whose auth (Google/GitHub OAuth + email/password), Stripe subscriptions and teams run inside your own app, so no hosted auth vendor is needed.

- Repo: https://github.com/mailkite/saas-startup
- Live demo: https://saas-startup.mailkite.dev

Category: `web-apis` (it exists to build and ship a web app; if you'd rather file starter kits under `developer-tools-cli`, happy to move it). The repo is new and has few stars yet — stating that up front rather than hiding it.

## Checklist

- [x] I edited **only** `data/tools.json` (not README.md — it's generated)
- [x] One tool in this PR
- [x] Public repo with an OSI-approved license, and the `license` field matches
- [x] Description is one honest sentence, 140 characters max — no hype
- [x] `category` is one of the slugs listed in CONTRIBUTING.md
- [x] No star counts or other metrics typed by hand (they're fetched automatically)
