### PR TITLE
Add Sitemap Cohort Auditor to tools.json

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -3503,5 +3503,14 @@
     "description": "MIT-licensed CLI that validates rights-aware metadata for AI-hybrid video-production deliveries.",
     "license": "MIT",
     "added": "2026-09-10"
+  },
+  {
+    "name": "Sitemap Cohort Auditor",
+    "repo": "edilec/sitemap-cohort-auditor",
+    "homepage": "https://github.com/edilec/sitemap-cohort-auditor",
+    "category": "developer-tools-cli",
+    "description": "Node.js CLI for comparing sitemap URL cohorts between releases and reporting declared URL and image coverage.",
+    "license": "MIT",
+    "added": "2026-09-10"
   }
 ]


### PR DESCRIPTION
Adds Sitemap Cohort Auditor, a public MIT-licensed Node.js CLI, as a single developer-tools-cli entry.

Repository: https://github.com/edilec/sitemap-cohort-auditor

## What tool are you dropping?

Sitemap Cohort Auditor — compares sitemap URL cohorts and reports declared URL and image coverage.

## Checklist

- [x] I edited **only** `data/tools.json` (not README.md — it's generated)
- [x] One tool in this PR
- [x] Public repo with an OSI-approved license, and the `license` field matches
- [x] Description is one honest sentence, 140 characters max — no hype
- [x] `category` is one of the slugs listed in CONTRIBUTING.md
- [x] No star counts or other metrics typed by hand (they're fetched automatically)