### PR TITLE
Add PuppyOne to notes-knowledge

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -3512,5 +3512,14 @@
     "description": "Node.js CLI for comparing sitemap URL cohorts between releases and reporting declared URL and image coverage.",
     "license": "MIT",
     "added": "2026-09-10"
+  },
+  {
+    "name": "PuppyOne",
+    "repo": "puppyone-ai/puppyone-desktop",
+    "homepage": "https://www.puppyone.ai",
+    "category": "notes-knowledge",
+    "description": "Local-first workspace where you and your AI work on the same project files with built-in version history.",
+    "license": "Apache-2.0",
+    "added": "2026-09-10"
   }
 ]


### PR DESCRIPTION
Open-source Apache-2.0 local-first workspace for documents/notes/PDFs with AI on the same files and version history. Fits notes-knowledge as an Obsidian/Notion-style knowledge workspace (not a coding IDE). Repo: https://github.com/puppyone-ai/puppyone-desktop