### PR TITLE
Add OrcaReplay to tools.json

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -3521,5 +3521,14 @@
     "description": "Local-first workspace where you and your AI work on the same project files with built-in version history.",
     "license": "Apache-2.0",
     "added": "2026-09-10"
+  },
+  {
+    "name": "OrcaReplay",
+    "repo": "Continuum-AI-Corp/OrcaReplay",
+    "homepage": "https://github.com/Continuum-AI-Corp/OrcaReplay",
+    "category": "ai-coding-agents",
+    "description": "Records a coding agent's session and replays it offline, for developers debugging agent runs without spending tokens.",
+    "license": "Apache-2.0",
+    "added": "2026-09-10"
   }
 ]


### PR DESCRIPTION
One tool, one object in `data/tools.json`, README untouched.

```json
{
  "name": "OrcaReplay",
  "repo": "Continuum-AI-Corp/OrcaReplay",
  "homepage": "https://github.com/Continuum-AI-Corp/OrcaReplay",
  "category": "ai-coding-agents",
  "description": "Records a coding agent's session and replays it offline, for developers debugging agent runs without spending tokens.",
  "license": "Apache-2.0",
  "added": "2026-09-10"
}
```

**It's my own tool** — CONTRIBUTING says that's encouraged, so I'm saying it plainly rather than burying it.

## Against your checklist

- **Open source** — Apache-2.0, public repo, no open-core split and no paid tier. `license` matches the `LICENSE` file.
- **Category** — `ai-coding-agents`, on the "agent infrastructure" clause. It is a CLI, so `developer-tools-cli` was tempting, but your rule is to pick what the tool *does*: it exists only to record and re-run AI coding agents, and it is useless without one. If you read the boundary the other way, move it and I won't argue.
- **Description** — 117 characters, one sentence, what it does plus who for. No feature list, no superlatives, no emoji, no star numbers anywhere.
- **`links`** — omitted. The docs live in the repo you already link, so a second link would just be a second link.
- **Not a duplicate** — grepped `tools.json`; nothing matches.

## What it actually does, since the description has to be short

It sits in front of a coding agent as a local proxy and keeps the verbatim request and response bytes. That costs disk and buys one thing: the recording can be served back to the agent, so the agent runs again.

```console
$ orca record claude -- -p "fix the failing test"
$ orca replay last
info replaying exchanges=8 egress=blocked
info replay.done reused=8/8 exact=8 divergences=0 exit=0
```

No provider is called on the replay and no tokens are spent. Nothing is installed into the agent — no plugin, no SDK — which is how one tool covers Claude Code, Codex, goose, OpenCode, Cursor, CrewAI and OpenHands.

One honesty note about the word "offline" in the description: it means **no model provider is called**. Replay still executes recorded tool calls for real, so a recorded `curl` reaches the network. It is not a sandbox, and the README says so.

JSON validated with `json.loads` before pushing; the file parses and gains exactly one entry (377 → 378).
