### PR TITLE
Add ProofKey

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -3539,5 +3539,14 @@
     "description": "Blender add-on that builds named low-poly indie game props from JSON recipes with known triangle budgets.",
     "license": "Apache-2.0",
     "added": "2026-09-11"
+  },
+  {
+    "name": "ProofKey",
+    "repo": "jiru-labs/proofkey",
+    "homepage": "https://github.com/jiru-labs/proofkey",
+    "category": "productivity",
+    "description": "Grammarly-style grammar checks and rewrites in Chrome, sent only to your own LLM API key or a local model. No backend, no telemetry.",
+    "license": "MIT",
+    "added": "2026-09-11"
   }
 ]


### PR DESCRIPTION
One tool, category `productivity` (same as GemType, which it is closest to). ProofKey is a Chrome extension with Grammarly-style inline grammar checking and rewrites; the text goes only to the LLM endpoint the user configures with their own API key, or to a local model. MIT, public repo, no backend, no telemetry. I maintain it.